### PR TITLE
DDF-2480 Fixed Updload dialog to reopen if closed during an upload

### DIFF
--- a/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestModal.view.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/view/ingest/IngestModal.view.js
@@ -37,8 +37,6 @@ define([
             },
             initialize: function () {
                 // there is no automatic chaining of initialize.
-                Modal.prototype.initialize.apply(this, arguments);
-
                 this.model = new Backbone.Model({
                     state: 'start'
                 });


### PR DESCRIPTION
#### What does this PR do?  Fixes the Search UI file upload dialog so it can be reopened if its closed while resources are being uploaded.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@andrewkfiedler
@jrnorth
@azgoalie
@emanns95 
@ahoffer
@NGoss
@spearskw
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@jlcsmith
#### How should this be tested?

Open the file upload dialog and select two large files to upload. While the uploads are in progress, close the dialog using the x. Once the dialog has been closed, it cannot be re-opened.
#### Any background context you want to provide?

This was caused by a change made in DDF-1643
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
